### PR TITLE
object: add experimental strict OBC bucketOwner mode

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `nodeSelector` | Kubernetes [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) to add to the Deployment. | `{}` |
 | `obcAllowAdditionalConfigFields` | Many OBC additional config fields may be risky for administrators to allow users control over. The safe and default-allowed fields are 'maxObjects' and 'maxSize'. Other fields should be considered risky. To allow all additional configs, use this value:   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner" | "maxObjects,maxSize" |
 | `obcProvisionerNamePrefix` | Specify the prefix for the OBC provisioner in place of the cluster namespace | `ceph cluster namespace` |
+| `obcStrictBucketOwner` | EXPERIMENTAL: If true, every OBC must set `additionalConfig.bucketOwner` to the name of a CephObjectStoreUser in the OBC's namespace, OBC credential secrets never contain S3 keys (credentials come from the CephObjectStoreUser's secret; keys handed out before the mode was enabled are revoked), and deleting a CephObjectStoreUser is blocked while OBCs reference it | `false` |
 | `operatorPodLabels` | Custom pod labels for the operator | `{}` |
 | `priorityClassName` | Set the priority class for the rook operator deployment if desired | `nil` |
 | `rbacAggregate.enableOBCs` | If true, create a ClusterRole aggregated to [user facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) for objectbucketclaims | `false` |

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
@@ -111,6 +111,44 @@ are personally willing to take on the risks.
 OBC `additionalConfig` fields can be enabled and disabled using the `rook-ceph-operator-config`
 configmap value `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`.
 
+### Strict bucketOwner mode (experimental)
+
+By default, any OBC allowed to set `bucketOwner` can name an arbitrary rgw user, and the OBC's
+credentials secret receives that user's S3 keys. That effectively lets anyone who can create an OBC
+read the S3 credentials of any rgw user on the object store.
+
+Setting `ROOK_OBC_STRICT_BUCKET_OWNER: "true"` in the `rook-ceph-operator-config` configmap
+enables a strict mode that changes OBC provisioning behavior:
+
+* Every OBC must set `additionalConfig.bucketOwner` (the field is implicitly allowed, without an
+    entry in `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS`). The provisioner no longer generates
+    per-OBC rgw users.
+* `bucketOwner` must be the name of a `CephObjectStoreUser` in the same namespace as the OBC, and
+    that user must belong to the same object store as the OBC's storage class. For an OBC in a
+    namespace other than the Ceph cluster namespace, the `CephObjectStoreUser` must set
+    `spec.clusterNamespace`.
+* OBC credentials secrets never contain S3 keys. Applications read credentials from the
+    referenced `CephObjectStoreUser`'s own secret (`rook-ceph-object-user-<store>-<user>`) instead.
+    The OBC configmap still provides the bucket endpoint. (The OBC secret object itself still
+    exists, but empty: the bucket provisioning library unconditionally creates it.)
+* S3 keys handed out before strict mode was enabled are revoked as OBCs are reconciled: a
+    conforming OBC's secret is deleted and recreated without keys, and a violating OBC's secret is
+    deleted outright.
+* When an OBC created before strict mode transitions to an explicit `bucketOwner`, its bucket is
+    relinked to that owner and the rgw user the provisioner had generated for the OBC is removed,
+    revoking that user's keys. (Exception: for brownfield OBCs — pre-existing buckets named by the
+    storage class — the previously generated user is not removed automatically and should be
+    cleaned up manually.)
+* An OBC that violates the policy fails provisioning.
+* Deleting a `CephObjectStoreUser` is blocked while any OBC references it via `bucketOwner`;
+    delete the referencing OBCs first.
+
+Enabling strict mode on a cluster with existing OBCs breaks every OBC that does not conform, and
+removes the S3 keys from all OBC credentials secrets as the OBCs are reconciled. Before enabling
+it, create a `CephObjectStoreUser` for each OBC's owner in the OBC's namespace, set
+`additionalConfig.bucketOwner` on every OBC, and switch applications to consume the
+`CephObjectStoreUser` secret.
+
 ### OBC Custom Resource after Bucket Provisioning
 
 ```yaml

--- a/deploy/charts/rook-ceph/templates/configmap.yaml
+++ b/deploy/charts/rook-ceph/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   {{- with .Values.obcAllowAdditionalConfigFields }}
   ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: {{ . | quote }}
   {{- end }}
+  ROOK_OBC_STRICT_BUCKET_OWNER: {{ .Values.obcStrictBucketOwner | quote }}
   ROOK_CEPH_ALLOW_LOOP_DEVICES: {{ .Values.allowLoopDevices | quote }}
   ROOK_CEPH_MON_RUN_AS_ROOT: {{ .Values.monRunAsRoot | quote }}
   ROOK_DELETE_UNUSED_CRUSH_RULES: {{ .Values.deleteUnusedCrushRules | quote }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -234,6 +234,12 @@ obcProvisionerNamePrefix:
 # @default -- "maxObjects,maxSize"
 obcAllowAdditionalConfigFields: "maxObjects,maxSize"
 
+# -- EXPERIMENTAL: If true, every OBC must set `additionalConfig.bucketOwner` to the name of a
+# CephObjectStoreUser in the OBC's namespace, OBC credential secrets never contain S3 keys
+# (credentials come from the CephObjectStoreUser's secret; keys handed out before the mode was
+# enabled are revoked), and deleting a CephObjectStoreUser is blocked while OBCs reference it
+obcStrictBucketOwner: false
+
 monitoring:
   # -- Enable monitoring. Requires Prometheus to be pre-installed.
   # Enabling will also create RBAC rules to allow Operator to create ServiceMonitors

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -47,6 +47,13 @@ data:
   #   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
   # ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs
 
+  # EXPERIMENTAL: If true, every OBC must set additionalConfig.bucketOwner to the name of a
+  # CephObjectStoreUser in the OBC's namespace, OBC credential secrets never contain S3 keys
+  # (credentials come from the CephObjectStoreUser's secret; keys handed out before the mode was
+  # enabled are revoked), and deleting a CephObjectStoreUser is blocked while OBCs reference it.
+  # OBCs violating the policy fail provisioning.
+  # ROOK_OBC_STRICT_BUCKET_OWNER: "false"
+
   # Whether to start the discovery daemon to watch for raw storage devices on nodes in the cluster.
   # This daemon does not need to run if you are only going to create your OSDs based on StorageClassDeviceSets with PVCs.
   ROOK_ENABLE_DISCOVERY_DAEMON: "false"

--- a/pkg/operator/ceph/controller.go
+++ b/pkg/operator/ceph/controller.go
@@ -128,6 +128,7 @@ func (r *ReconcileConfig) reconcile(request reconcile.Request) (reconcile.Result
 	opcontroller.SetEnforceHostNetwork()
 	opcontroller.SetRevisionHistoryLimit()
 	opcontroller.SetObcAllowAdditionalConfigFields()
+	opcontroller.SetObcStrictBucketOwner()
 
 	logger.Infof("%s done reconciling", controllerName)
 	return reconcile.Result{}, nil

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -59,6 +59,8 @@ const (
 	obcAllowAdditionalConfigFieldsSettingName  string = "ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS"
 	obcAllowAdditionalConfigFieldsDefaultValue string = "maxObjects,maxSize"
 
+	obcStrictBucketOwnerSettingName string = "ROOK_OBC_STRICT_BUCKET_OWNER"
+
 	revisionHistoryLimitSettingName string = "ROOK_REVISION_HISTORY_LIMIT"
 
 	// UninitializedCephConfigError refers to the error message printed by the Ceph CLI when there is no ceph configuration file
@@ -94,6 +96,8 @@ var (
 
 	// allowed OBC additional config fields
 	obcAllowAdditionalConfigFields = strings.Split(obcAllowAdditionalConfigFieldsDefaultValue, ",")
+
+	obcStrictBucketOwner = false
 )
 
 func DiscoveryDaemonEnabled() bool {
@@ -169,6 +173,20 @@ func SetObcAllowAdditionalConfigFields() {
 
 func ObcAdditionalConfigKeyIsAllowed(configField string) bool {
 	return slices.Contains(obcAllowAdditionalConfigFields, configField)
+}
+
+func SetObcStrictBucketOwner() {
+	strval := k8sutil.GetOperatorSetting(obcStrictBucketOwnerSettingName, "false")
+	var err error
+	obcStrictBucketOwner, err = strconv.ParseBool(strval)
+	if err != nil {
+		logger.Warningf("%s is set to an invalid value %q, set the default value false", obcStrictBucketOwnerSettingName, strval)
+		obcStrictBucketOwner = false
+	}
+}
+
+func ObcStrictBucketOwner() bool {
+	return obcStrictBucketOwner
 }
 
 // canIgnoreHealthErrStatusInReconcile determines whether a status of HEALTH_ERR in the CephCluster can be ignored safely.

--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -342,3 +342,30 @@ func TestObcAllowAdditionalConfigFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSetObcStrictBucketOwner(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{"not set", "<notset>", false},
+		{"set to true", "true", true},
+		{"set to false", "false", false},
+		{"set to 1", "1", true},
+		{"invalid value", "banana", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "<notset>" {
+				t.Setenv("ROOK_OBC_STRICT_BUCKET_OWNER", tt.value)
+			}
+			SetObcStrictBucketOwner()
+			t.Cleanup(func() {
+				os.Unsetenv("ROOK_OBC_STRICT_BUCKET_OWNER")
+				SetObcStrictBucketOwner()
+			})
+			assert.Equal(t, tt.expected, ObcStrictBucketOwner())
+		})
+	}
+}

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -19,6 +19,7 @@ package operator
 import (
 	"context"
 
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/client"
@@ -61,6 +62,7 @@ import (
 var resourcesSchemeFuncs = []func(*runtime.Scheme) error{
 	clientgoscheme.AddToScheme,
 	cephv1.AddToScheme,
+	bktv1alpha1.AddToScheme,
 }
 
 // EnableMachineDisruptionBudget checks whether machine disruption budget is enabled

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -107,6 +107,11 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	if err != nil {
 		return nil, err
 	}
+
+	err = p.enforceStrictBucketOwner(bucket)
+	if err != nil {
+		return nil, err
+	}
 	log.NamedInfo(nsName, logger, "Provision: creating bucket %q for OBC %q", p.bucketName, options.ObjectBucketClaim.Name)
 
 	p.accessKeyID, p.secretAccessKey, err = bucket.getUserCreds()
@@ -161,6 +166,11 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		return nil, errors.Wrapf(err, "failed to set additional settings for OBC %q in NS %q associated with CephObjectStore %q in NS %q", options.ObjectBucketClaim.Name, options.ObjectBucketClaim.Namespace, p.objectStoreName, p.clusterInfo.Namespace)
 	}
 
+	err = p.deleteTransitionedGeneratedUser(bucket)
+	if err != nil {
+		return nil, err
+	}
+
 	return p.composeObjectBucket(bucket), nil
 }
 
@@ -179,6 +189,11 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 
 	// initialize and set the AWS services and commonly used variables
 	err = p.initializeCreateOrGrant(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.enforceStrictBucketOwner(bucket)
 	if err != nil {
 		return nil, err
 	}
@@ -488,6 +503,18 @@ func (p *Provisioner) initializeDeleteOrRevoke(ob *bktv1alpha1.ObjectBucket) err
 
 // Return the OB struct with minimal fields filled in.
 func (p *Provisioner) composeObjectBucket(bucket *bucket) *bktv1alpha1.ObjectBucket {
+	// in strict bucketOwner mode the owner's S3 keys are delivered via the
+	// CephObjectStoreUser's own secret, so they are withheld from the OB.
+	// lib-bucket requires non-nil Authentication and always creates the OBC's
+	// credentials secret; empty Authentication yields a secret with no keys.
+	auth := &bktv1alpha1.Authentication{}
+	if !opcontroller.ObcStrictBucketOwner() {
+		auth.AccessKeys = &bktv1alpha1.AccessKeys{
+			AccessKeyID:     p.accessKeyID,
+			SecretAccessKey: p.secretAccessKey,
+		}
+	}
+
 	conn := &bktv1alpha1.Connection{
 		Endpoint: &bktv1alpha1.Endpoint{
 			// if there are multiple endpoints on the object store, the OBC will get the endpoint
@@ -497,12 +524,7 @@ func (p *Provisioner) composeObjectBucket(bucket *bucket) *bktv1alpha1.ObjectBuc
 			BucketName:           p.bucketName,
 			AdditionalConfigData: p.additionalConfigData,
 		},
-		Authentication: &bktv1alpha1.Authentication{
-			AccessKeys: &bktv1alpha1.AccessKeys{
-				AccessKeyID:     p.accessKeyID,
-				SecretAccessKey: p.secretAccessKey,
-			},
-		},
+		Authentication: auth,
 		AdditionalState: map[string]string{
 			CephUser:             p.cephUserName,
 			ObjectStoreName:      p.objectStoreName,

--- a/pkg/operator/ceph/object/bucket/strict.go
+++ b/pkg/operator/ceph/object/bucket/strict.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"slices"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
+	"github.com/pkg/errors"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/log"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const bucketProvisionerFinalizer = apibkt.Domain + "/finalizer"
+
+// enforceStrictBucketOwner applies the ROOK_OBC_STRICT_BUCKET_OWNER policy:
+// every OBC must set additionalConfig.bucketOwner to the name of a
+// CephObjectStoreUser in the OBC's own namespace that belongs to the OBC's
+// object store. In strict mode no OBC credentials secret may exist, so any
+// secret left over from provisioning done before the mode was enabled is
+// deleted whether the OBC conforms or not. Errors that may be transient
+// (e.g. API server failures) fail the reconcile without touching the secret.
+func (p *Provisioner) enforceStrictBucketOwner(bucket *bucket) error {
+	if !opcontroller.ObcStrictBucketOwner() {
+		return nil
+	}
+
+	obc := bucket.options.ObjectBucketClaim
+
+	bucketOwner := bucket.additionalConfig.bucketOwner
+	if bucketOwner == nil {
+		p.deleteCredentialsSecret(obc)
+		return errors.Errorf("strict bucketOwner mode: OBC %q/%q must set additionalConfig.bucketOwner to the name of a CephObjectStoreUser in namespace %q", obc.Namespace, obc.Name, obc.Namespace)
+	}
+
+	user, err := p.context.RookClientset.CephV1().CephObjectStoreUsers(obc.Namespace).Get(p.clusterInfo.Context, *bucketOwner, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			p.deleteCredentialsSecret(obc)
+			return errors.Errorf("strict bucketOwner mode: bucketOwner %q of OBC %q/%q does not reference a CephObjectStoreUser in namespace %q", *bucketOwner, obc.Namespace, obc.Name, obc.Namespace)
+		}
+		return errors.Wrapf(err, "failed to get CephObjectStoreUser %q/%q referenced by OBC %q", obc.Namespace, *bucketOwner, obc.Name)
+	}
+
+	if !user.GetDeletionTimestamp().IsZero() {
+		return errors.Errorf("strict bucketOwner mode: CephObjectStoreUser %q/%q referenced by OBC %q is being deleted", user.Namespace, user.Name, obc.Name)
+	}
+
+	if user.Spec.Store != p.objectStoreName {
+		p.deleteCredentialsSecret(obc)
+		return errors.Errorf("strict bucketOwner mode: CephObjectStoreUser %q/%q belongs to object store %q, but OBC %q uses object store %q", user.Namespace, user.Name, user.Spec.Store, obc.Name, p.objectStoreName)
+	}
+
+	userClusterNamespace := user.Spec.ClusterNamespace
+	if userClusterNamespace == "" {
+		userClusterNamespace = user.Namespace
+	}
+	if userClusterNamespace != p.clusterInfo.Namespace {
+		p.deleteCredentialsSecret(obc)
+		return errors.Errorf("strict bucketOwner mode: CephObjectStoreUser %q/%q targets Ceph cluster namespace %q, but OBC %q uses a CephObjectStore in namespace %q", user.Namespace, user.Name, userClusterNamespace, obc.Name, p.clusterInfo.Namespace)
+	}
+
+	// the OBC conforms; remove any credentials secret left over from
+	// provisioning done before strict mode was enabled
+	p.deleteCredentialsSecret(obc)
+
+	return nil
+}
+
+// deleteTransitionedGeneratedUser removes the rgw user the provisioner
+// generated for the OBC before strict bucketOwner mode took effect. Relinking
+// the bucket to the explicit bucketOwner orphans the generated user with
+// valid S3 keys, and once the OB records the new owner nothing else remembers
+// the generated user's name. The name is deterministic, so this runs on every
+// reconcile after ownership is settled rather than only at relink time; a
+// removal that fails is retried by the next reconcile.
+func (p *Provisioner) deleteTransitionedGeneratedUser(bucket *bucket) error {
+	if !opcontroller.ObcStrictBucketOwner() {
+		return nil
+	}
+
+	obc := bucket.options.ObjectBucketClaim
+	generatedUser := p.genUserName(obc)
+	// an explicit bucketOwner may deliberately adopt the generated user
+	if generatedUser == p.cephUserName {
+		return nil
+	}
+
+	err := p.adminOpsClient.RemoveUser(p.clusterInfo.Context, admin.User{ID: generatedUser})
+	if err != nil {
+		if errors.Is(err, admin.ErrNoSuchUser) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to remove provisioner-generated user %q orphaned by OBC %q/%q transitioning to bucketOwner %q", generatedUser, obc.Namespace, obc.Name, p.cephUserName)
+	}
+
+	log.NamedInfo(p.objectContext.NsName(), logger, "removed provisioner-generated user %q orphaned by OBC %q/%q transitioning to bucketOwner %q", generatedUser, obc.Namespace, obc.Name, p.cephUserName)
+	return nil
+}
+
+// deleteCredentialsSecret removes the credentials secret lib-bucket created for
+// the OBC, revoking S3 keys handed out before strict mode was enabled. For an
+// OBC that fails the strict policy the reconcile fails, so lib-bucket does not
+// recreate the secret; for a conforming OBC lib-bucket recreates it after a
+// successful Provision/Grant, but with no keys in it (see
+// composeObjectBucket). Best-effort: a failed deletion is retried on the next
+// reconcile.
+func (p *Provisioner) deleteCredentialsSecret(obc *bktv1alpha1.ObjectBucketClaim) {
+	nsName := p.objectContext.NsName()
+
+	// lib-bucket names the credentials secret after the OBC
+	secrets := p.context.Clientset.CoreV1().Secrets(obc.Namespace)
+	secret, err := secrets.Get(p.clusterInfo.Context, obc.Name, metav1.GetOptions{})
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			log.NamedWarning(nsName, logger, "failed to get credentials secret of OBC %q/%q. %v", obc.Namespace, obc.Name, err)
+		}
+		return
+	}
+
+	ownedByOBC := slices.ContainsFunc(secret.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.UID == obc.UID
+	})
+	if !ownedByOBC {
+		log.NamedWarning(nsName, logger, "not deleting secret %q/%q: it is not owned by OBC %q", secret.Namespace, secret.Name, obc.Name)
+		return
+	}
+
+	finalizers := slices.DeleteFunc(slices.Clone(secret.Finalizers), func(f string) bool {
+		return f == bucketProvisionerFinalizer
+	})
+	if len(finalizers) != len(secret.Finalizers) {
+		secret.Finalizers = finalizers
+		if secret, err = secrets.Update(p.clusterInfo.Context, secret, metav1.UpdateOptions{}); err != nil {
+			log.NamedWarning(nsName, logger, "failed to remove finalizer from credentials secret of OBC %q/%q. %v", obc.Namespace, obc.Name, err)
+			return
+		}
+	}
+
+	if err := secrets.Delete(p.clusterInfo.Context, secret.Name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		log.NamedWarning(nsName, logger, "failed to delete credentials secret of OBC %q/%q. %v", obc.Namespace, obc.Name, err)
+		return
+	}
+	log.NamedInfo(nsName, logger, "deleted credentials secret of OBC %q/%q", obc.Namespace, obc.Name)
+}

--- a/pkg/operator/ceph/object/bucket/strict_test.go
+++ b/pkg/operator/ceph/object/bucket/strict_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	strictTestNamespace        = "app-ns"
+	strictTestClusterNamespace = "rook-ceph"
+	strictTestStore            = "test-store"
+	strictTestOBCName          = "my-obc"
+)
+
+var strictTestOBCUID = types.UID("6e7c4d3f-3494-4dc1-90dc-58527fdf05d7")
+
+func enableStrictBucketOwner(t *testing.T) {
+	t.Setenv("ROOK_OBC_STRICT_BUCKET_OWNER", "true")
+	opcontroller.SetObcStrictBucketOwner()
+	t.Cleanup(func() {
+		os.Unsetenv("ROOK_OBC_STRICT_BUCKET_OWNER")
+		opcontroller.SetObcStrictBucketOwner()
+	})
+}
+
+func strictTestOBC(bucketOwner *string) *bktv1alpha1.ObjectBucketClaim {
+	obc := &bktv1alpha1.ObjectBucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strictTestOBCName,
+			Namespace: strictTestNamespace,
+			UID:       strictTestOBCUID,
+		},
+	}
+	if bucketOwner != nil {
+		obc.Spec.AdditionalConfig = map[string]string{"bucketOwner": *bucketOwner}
+	}
+	return obc
+}
+
+func strictTestSecret(ownerUID types.UID) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       strictTestOBCName,
+			Namespace:  strictTestNamespace,
+			Finalizers: []string{bucketProvisionerFinalizer},
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "objectbucket.io/v1alpha1", Kind: "ObjectBucketClaim", Name: strictTestOBCName, UID: ownerUID},
+			},
+		},
+		StringData: map[string]string{"AWS_ACCESS_KEY_ID": "u", "AWS_SECRET_ACCESS_KEY": "p"},
+	}
+}
+
+func strictTestUser(mutate func(*cephv1.CephObjectStoreUser)) *cephv1.CephObjectStoreUser {
+	u := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner-user",
+			Namespace: strictTestNamespace,
+		},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store:            strictTestStore,
+			ClusterNamespace: strictTestClusterNamespace,
+		},
+	}
+	if mutate != nil {
+		mutate(u)
+	}
+	return u
+}
+
+func strictTestProvisioner(t *testing.T, rookObjs []runtime.Object, k8sObjs []runtime.Object) *Provisioner {
+	clusterInfo := client.AdminTestClusterInfo(strictTestClusterNamespace)
+	p := NewProvisioner(&clusterd.Context{
+		RookClientset: rookclient.NewSimpleClientset(rookObjs...),
+		Clientset:     k8sfake.NewSimpleClientset(k8sObjs...),
+	}, clusterInfo)
+	p.objectContext = object.NewContext(p.context, clusterInfo, strictTestStore)
+	p.objectStoreName = strictTestStore
+	return p
+}
+
+func strictTestBucket(p *Provisioner, bucketOwner *string) *bucket {
+	return &bucket{
+		provisioner:      p,
+		options:          &apibkt.BucketOptions{ObjectBucketClaim: strictTestOBC(bucketOwner)},
+		additionalConfig: &additionalConfigSpec{bucketOwner: bucketOwner},
+	}
+}
+
+func assertSecretDeleted(t *testing.T, p *Provisioner, deleted bool) {
+	t.Helper()
+	_, err := p.context.Clientset.CoreV1().Secrets(strictTestNamespace).Get(p.clusterInfo.Context, strictTestOBCName, metav1.GetOptions{})
+	if deleted {
+		assert.True(t, kerrors.IsNotFound(err))
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
+func TestEnforceStrictBucketOwner(t *testing.T) {
+	owner := "owner-user"
+
+	t.Run("mode off allows OBC without bucketOwner", func(t *testing.T) {
+		p := strictTestProvisioner(t, nil, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, nil))
+		assert.NoError(t, err)
+		assertSecretDeleted(t, p, false)
+	})
+
+	t.Run("no bucketOwner fails and deletes the secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p := strictTestProvisioner(t, nil, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must set additionalConfig.bucketOwner")
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("missing CephObjectStoreUser fails and deletes the secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p := strictTestProvisioner(t, nil, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not reference a CephObjectStoreUser")
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("user of another store fails and deletes the secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		u := strictTestUser(func(u *cephv1.CephObjectStoreUser) { u.Spec.Store = "other-store" })
+		p := strictTestProvisioner(t, []runtime.Object{u}, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "belongs to object store")
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("user of another cluster namespace fails and deletes the secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		u := strictTestUser(func(u *cephv1.CephObjectStoreUser) { u.Spec.ClusterNamespace = "other-cluster" })
+		p := strictTestProvisioner(t, []runtime.Object{u}, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "targets Ceph cluster namespace")
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("user without clusterNamespace defaults to its own namespace", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		u := strictTestUser(func(u *cephv1.CephObjectStoreUser) { u.Spec.ClusterNamespace = "" })
+		p := strictTestProvisioner(t, []runtime.Object{u}, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "targets Ceph cluster namespace")
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("user being deleted fails without deleting the secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		now := metav1.Now()
+		u := strictTestUser(func(u *cephv1.CephObjectStoreUser) {
+			u.DeletionTimestamp = &now
+			u.Finalizers = []string{"cephobjectstoreuser.ceph.rook.io"}
+		})
+		p := strictTestProvisioner(t, []runtime.Object{u}, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is being deleted")
+		assertSecretDeleted(t, p, false)
+	})
+
+	t.Run("valid reference passes and deletes the stale secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p := strictTestProvisioner(t, []runtime.Object{strictTestUser(nil)}, []runtime.Object{strictTestSecret(strictTestOBCUID)})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		assert.NoError(t, err)
+		assertSecretDeleted(t, p, true)
+	})
+
+	t.Run("valid reference passes without a stale secret", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p := strictTestProvisioner(t, []runtime.Object{strictTestUser(nil)}, nil)
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, &owner))
+		assert.NoError(t, err)
+	})
+
+	t.Run("secret not owned by the OBC is left alone", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p := strictTestProvisioner(t, nil, []runtime.Object{strictTestSecret(types.UID("some-other-uid"))})
+		err := p.enforceStrictBucketOwner(strictTestBucket(p, nil))
+		require.Error(t, err)
+		assertSecretDeleted(t, p, false)
+	})
+}
+
+func TestComposeObjectBucketStrictBucketOwner(t *testing.T) {
+	owner := "owner-user"
+
+	newTestProvisioner := func(t *testing.T) (*Provisioner, *bucket) {
+		p := strictTestProvisioner(t, nil, nil)
+		p.accessKeyID = "AKID"
+		p.secretAccessKey = "SECRET"
+		p.cephUserName = owner
+		p.bucketName = "bkt"
+		p.storeDomainName = "s3.example.com"
+		p.storePort = 443
+		return p, strictTestBucket(p, &owner)
+	}
+
+	t.Run("mode off includes access keys", func(t *testing.T) {
+		p, b := newTestProvisioner(t)
+		ob := p.composeObjectBucket(b)
+		require.NotNil(t, ob.Spec.Authentication.AccessKeys)
+		assert.Equal(t, "AKID", ob.Spec.Authentication.AccessKeys.AccessKeyID)
+		assert.Equal(t, "SECRET", ob.Spec.Authentication.AccessKeys.SecretAccessKey)
+	})
+
+	t.Run("strict mode withholds access keys", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		p, b := newTestProvisioner(t)
+		ob := p.composeObjectBucket(b)
+		require.NotNil(t, ob.Spec.Authentication)
+		assert.Nil(t, ob.Spec.Authentication.AccessKeys)
+		assert.Empty(t, ob.Spec.Authentication.ToMap())
+	})
+}
+
+func TestDeleteTransitionedGeneratedUser(t *testing.T) {
+	newAdminClient := func(t *testing.T, deleteStatus int, deleteBody string, deleteSeen *[]string) *admin.API {
+		mockClient := &object.MockClient{
+			MockDo: func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodDelete || req.URL.Path != userPath {
+					panic(fmt.Sprintf("unexpected request: method %q path %q", req.Method, req.URL.Path))
+				}
+				*deleteSeen = append(*deleteSeen, req.URL.RawQuery)
+				return &http.Response{
+					StatusCode: deleteStatus,
+					Body:       io.NopCloser(bytes.NewReader([]byte(deleteBody))),
+				}, nil
+			},
+		}
+		adminClient, err := admin.New("rgw.test", "accesskey", "secretkey", mockClient)
+		require.NoError(t, err)
+		return adminClient
+	}
+
+	newTestProvisioner := func(t *testing.T, deleteStatus int, deleteBody string, deleteSeen *[]string) (*Provisioner, *bucket) {
+		owner := "owner-user"
+		p := strictTestProvisioner(t, nil, nil)
+		p.cephUserName = owner
+		p.adminOpsClient = newAdminClient(t, deleteStatus, deleteBody, deleteSeen)
+		return p, strictTestBucket(p, &owner)
+	}
+
+	t.Run("mode off does nothing", func(t *testing.T) {
+		deleteSeen := []string{}
+		p, b := newTestProvisioner(t, 200, `{}`, &deleteSeen)
+		err := p.deleteTransitionedGeneratedUser(b)
+		assert.NoError(t, err)
+		assert.Empty(t, deleteSeen)
+	})
+
+	t.Run("generated user is removed", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		deleteSeen := []string{}
+		p, b := newTestProvisioner(t, 200, `{}`, &deleteSeen)
+		err := p.deleteTransitionedGeneratedUser(b)
+		assert.NoError(t, err)
+		require.Len(t, deleteSeen, 1)
+		assert.Contains(t, deleteSeen[0], "uid=obc-"+strictTestNamespace+"-"+strictTestOBCName+"-"+string(strictTestOBCUID))
+	})
+
+	t.Run("missing generated user is not an error", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		deleteSeen := []string{}
+		p, b := newTestProvisioner(t, 404, `{"Code":"NoSuchUser"}`, &deleteSeen)
+		err := p.deleteTransitionedGeneratedUser(b)
+		assert.NoError(t, err)
+		assert.Len(t, deleteSeen, 1)
+	})
+
+	t.Run("removal failure is an error", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		deleteSeen := []string{}
+		p, b := newTestProvisioner(t, 500, `{"Code":"InternalError"}`, &deleteSeen)
+		err := p.deleteTransitionedGeneratedUser(b)
+		assert.Error(t, err)
+	})
+
+	t.Run("bucketOwner adopting the generated user is left alone", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		deleteSeen := []string{}
+		p, b := newTestProvisioner(t, 200, `{}`, &deleteSeen)
+		p.cephUserName = p.genUserName(b.options.ObjectBucketClaim)
+		err := p.deleteTransitionedGeneratedUser(b)
+		assert.NoError(t, err)
+		assert.Empty(t, deleteSeen)
+	})
+}
+
+func TestAdditionalConfigSpecStrictBucketOwner(t *testing.T) {
+	t.Run("strict mode implicitly allows bucketOwner", func(t *testing.T) {
+		enableStrictBucketOwner(t)
+		opcontroller.SetObcAllowAdditionalConfigFields()
+
+		spec, err := additionalConfigSpecFromMap(map[string]string{"bucketOwner": "foo"})
+		require.NoError(t, err)
+		require.NotNil(t, spec.bucketOwner)
+		assert.Equal(t, "foo", *spec.bucketOwner)
+	})
+}

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -151,7 +151,9 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 	}
 
 	if _, ok := config["bucketOwner"]; ok {
-		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketOwner") {
+		// strict bucketOwner mode requires bucketOwner on every OBC, so the
+		// field is implicitly allowed without an allow-list entry
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed("bucketOwner") && !opcontroller.ObcStrictBucketOwner() {
 			return nil, errors.Errorf("OBC config %q is not allowed", "bucketOwner")
 		}
 		bucketOwner := config["bucketOwner"]

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -322,6 +322,17 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		log.NamedDebug(request.NamespacedName, logger, "deleting object store user")
 		r.recorder.Eventf(cephObjectStoreUser, nil, corev1.EventTypeNormal, string(cephv1.ReconcileStarted), string(cephv1.ReconcileStarted), "deleting CephObjectStoreUser %q", cephObjectStoreUser.Name)
 
+		if opcontroller.ObcStrictBucketOwner() {
+			deps, err := r.referencingOBCs(cephObjectStoreUser)
+			if err != nil {
+				return reconcile.Result{}, *cephObjectStoreUser, errors.Wrapf(err, "failed to determine whether ObjectBucketClaims reference CephObjectStoreUser %q", request.NamespacedName)
+			}
+			if !deps.Empty() {
+				return opcontroller.WaitForRequeueIfFinalizerBlocked, *cephObjectStoreUser,
+					errors.New(deps.StringWithHeader("CephObjectStoreUser %q cannot be deleted until its dependents are deleted", request.NamespacedName.String()))
+			}
+		}
+
 		err := r.deleteUser(cephObjectStoreUser)
 		if err != nil {
 			return reconcile.Result{}, *cephObjectStoreUser, errors.Wrapf(err, "failed to delete ceph object user %q", cephObjectStoreUser.Name)

--- a/pkg/operator/ceph/object/user/dependents.go
+++ b/pkg/operator/ceph/object/user/dependents.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectuser
+
+import (
+	"fmt"
+
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
+	"github.com/rook/rook/pkg/util/dependents"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// referencingOBCs returns the ObjectBucketClaims whose
+// additionalConfig.bucketOwner names the given CephObjectStoreUser's rgw user
+// on the same object store. OBCs are listed across all namespaces: strict
+// bucketOwner mode only provisions same-namespace references, but OBCs
+// provisioned before the mode was enabled may reference the user from other
+// namespaces.
+func (r *ReconcileObjectStoreUser) referencingOBCs(u *cephv1.CephObjectStoreUser) (*dependents.DependentList, error) {
+	deps := dependents.NewDependentList()
+
+	obcs := &bktv1alpha1.ObjectBucketClaimList{}
+	if err := r.client.List(r.opManagerContext, obcs); err != nil {
+		// without the OBC CRD no OBC can reference the user
+		if meta.IsNoMatchError(err) {
+			return deps, nil
+		}
+		return nil, errors.Wrap(err, "failed to list ObjectBucketClaims")
+	}
+
+	for i := range obcs.Items {
+		obc := &obcs.Items[i]
+		if obc.Spec.AdditionalConfig["bucketOwner"] != u.Name {
+			continue
+		}
+
+		sc, err := r.context.Clientset.StorageV1().StorageClasses().Get(r.opManagerContext, obc.Spec.StorageClassName, metav1.GetOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get storage class %q of ObjectBucketClaim %q/%q", obc.Spec.StorageClassName, obc.Namespace, obc.Name)
+		}
+		if sc.Parameters[bucket.ObjectStoreName] != u.Spec.Store {
+			continue
+		}
+		if ns := sc.Parameters[bucket.ObjectStoreNamespace]; ns != "" && ns != clusterStoreNamespace(u) {
+			continue
+		}
+
+		deps.Add("ObjectBucketClaims", fmt.Sprintf("%s/%s", obc.Namespace, obc.Name))
+	}
+
+	return deps, nil
+}

--- a/pkg/operator/ceph/object/user/dependents_test.go
+++ b/pkg/operator/ceph/object/user/dependents_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectuser
+
+import (
+	"context"
+	"testing"
+
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReferencingOBCs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, cephv1.AddToScheme(scheme))
+	require.NoError(t, bktv1alpha1.AddToScheme(scheme))
+
+	user := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner-user", Namespace: "app-ns"},
+		Spec:       cephv1.ObjectStoreUserSpec{Store: "my-store", ClusterNamespace: "rook-ceph"},
+	}
+
+	newSC := func(name, store, storeNamespace string) *storagev1.StorageClass {
+		sc := &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Parameters: map[string]string{},
+		}
+		if store != "" {
+			sc.Parameters["objectStoreName"] = store
+		}
+		if storeNamespace != "" {
+			sc.Parameters["objectStoreNamespace"] = storeNamespace
+		}
+		return sc
+	}
+
+	newOBC := func(namespace, name, scName, bucketOwner string) *bktv1alpha1.ObjectBucketClaim {
+		obc := &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				StorageClassName: scName,
+			},
+		}
+		if bucketOwner != "" {
+			obc.Spec.AdditionalConfig = map[string]string{"bucketOwner": bucketOwner}
+		}
+		return obc
+	}
+
+	newReconciler := func(scs []runtime.Object, obcs ...*bktv1alpha1.ObjectBucketClaim) *ReconcileObjectStoreUser {
+		builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+		for _, obc := range obcs {
+			builder = builder.WithObjects(obc)
+		}
+		return &ReconcileObjectStoreUser{
+			client:           builder.Build(),
+			context:          &clusterd.Context{Clientset: k8sfake.NewSimpleClientset(scs...)},
+			opManagerContext: context.TODO(),
+		}
+	}
+
+	matchingSC := newSC("bucket-sc", "my-store", "rook-ceph")
+
+	t.Run("no OBCs", func(t *testing.T) {
+		r := newReconciler([]runtime.Object{matchingSC})
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("OBC referencing the user on the same store", func(t *testing.T) {
+		r := newReconciler([]runtime.Object{matchingSC}, newOBC("app-ns", "obc1", "bucket-sc", "owner-user"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"app-ns/obc1"}, deps.OfKind("ObjectBucketClaims"))
+	})
+
+	t.Run("cross-namespace OBC still counts", func(t *testing.T) {
+		r := newReconciler([]runtime.Object{matchingSC}, newOBC("other-ns", "obc2", "bucket-sc", "owner-user"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"other-ns/obc2"}, deps.OfKind("ObjectBucketClaims"))
+	})
+
+	t.Run("OBC without bucketOwner does not count", func(t *testing.T) {
+		r := newReconciler([]runtime.Object{matchingSC}, newOBC("app-ns", "obc3", "bucket-sc", ""))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("OBC referencing another user does not count", func(t *testing.T) {
+		r := newReconciler([]runtime.Object{matchingSC}, newOBC("app-ns", "obc4", "bucket-sc", "someone-else"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("OBC on another store does not count", func(t *testing.T) {
+		otherSC := newSC("other-sc", "other-store", "rook-ceph")
+		r := newReconciler([]runtime.Object{otherSC}, newOBC("app-ns", "obc5", "other-sc", "owner-user"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("OBC on another cluster namespace does not count", func(t *testing.T) {
+		otherSC := newSC("other-cluster-sc", "my-store", "other-cluster")
+		r := newReconciler([]runtime.Object{otherSC}, newOBC("app-ns", "obc6", "other-cluster-sc", "owner-user"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("storage class without namespace parameter counts on store match", func(t *testing.T) {
+		nsLessSC := newSC("nsless-sc", "my-store", "")
+		r := newReconciler([]runtime.Object{nsLessSC}, newOBC("app-ns", "obc7", "nsless-sc", "owner-user"))
+		deps, err := r.referencingOBCs(user)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"app-ns/obc7"}, deps.OfKind("ObjectBucketClaims"))
+	})
+
+	t.Run("missing storage class is an error", func(t *testing.T) {
+		r := newReconciler(nil, newOBC("app-ns", "obc8", "no-such-sc", "owner-user"))
+		_, err := r.referencingOBCs(user)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Experimental implementation for discussion; opened against the fork rather than rook/rook.

**Problem.** Once an admin allows the `bucketOwner` additionalConfig field, any principal who can create an OBC can name an arbitrary rgw user and receive that user's S3 keys in the OBC credentials secret — credential disclosure gated only by the ability to create OBCs.

**Strict bucketOwner mode.** A single operator setting, `ROOK_OBC_STRICT_BUCKET_OWNER` (default `false`; existing behavior unchanged), turns bucketOwner references into verified, managed relationships:

- Every OBC must set `additionalConfig.bucketOwner` to the name of a `CephObjectStoreUser` in the OBC's own namespace, validated against the OBC's object store (`spec.store`) and Ceph cluster namespace (`spec.clusterNamespace`, defaulting to the CR's namespace). `bucketOwner` is implicitly allowed without a `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` entry, and provisioner-generated per-OBC rgw users are disabled.
- OBC credentials secrets never contain S3 keys: the provisioner returns empty `Authentication`, so the secret lib-bucket-provisioner creates carries no keys. Applications consume the `CephObjectStoreUser`'s own secret (`rook-ceph-object-user-<store>-<user>`); the OBC configmap still provides the bucket endpoint. The empty Secret object itself still exists — lib-bucket-provisioner unconditionally creates it and errors on nil `Authentication`, and changing the library is out of scope, so "no secret object at all" is not achievable from rook alone.
- A nonconforming OBC (missing `bucketOwner`, or a dangling/mismatched reference) fails reconcile with a descriptive error and has its credentials secret deleted; a conforming OBC's pre-existing secret is deleted and recreated without keys. Either way, S3 keys handed out before the mode was enabled are revoked as OBCs reconcile (an operator restart reconciles all of them). Transient API errors never trigger secret deletion, and a reference to a `CephObjectStoreUser` that is mid-deletion fails the reconcile without touching the secret.
- An OBC transitioning from a provisioner-generated owner to an explicit `bucketOwner` has its bucket relinked and the now-orphaned generated rgw user removed, revoking its keys. The generated name is deterministic (`obc-<ns>-<name>-<uid>`), so the removal is checked on every reconcile rather than only at relink time (self-healing if an attempt fails); a `bucketOwner` deliberately adopting the generated user name is left alone.
- Deleting a `CephObjectStoreUser` is blocked (requeue + event via the reconcile-result recorder) while any OBC references it via `bucketOwner`, matched cluster-wide so OBCs from before the mode was enabled also count.

**Migration cliff (by design).** Enabling the gate on a cluster with existing OBCs breaks every nonconforming OBC and strips S3 keys from all OBC credentials secrets as OBCs are reconciled. The documented migration is: create a `CephObjectStoreUser` per owner in each OBC namespace, set `additionalConfig.bucketOwner` on every OBC, switch applications to the user secret, then flip the gate.

**Known gaps / follow-ups:**

- Brownfield OBCs (pre-existing buckets named by the storage class) do not get their old generated rgw user removed on transition: that user may be referenced by bucket policy statements, and removing it could wedge later policy updates on rgw versions that validate policy principals. Needs its own design discussion (statement cleanup ordering, user-managed `bucketPolicy` interplay).
- `CephObjectStoreUser` has no status `Conditions` field, so blocked deletion is reported via event + reconcile error rather than a `DeletionIsBlocked` condition (adding one requires a `pkg/apis` change).
- Deletion blocking matches OBC storage classes by `objectStoreName`/`objectStoreNamespace` parameters; endpoint-based (external) storage classes are not matched.
- The rgw-user-adoption sharp edge remains: a principal able to create a same-named `CephObjectStoreUser` in another namespace can still claim the same rgw user. The trust boundary is RBAC on `CephObjectStoreUser` creation.
- No integration tests yet; unit tests cover the enforcement matrix, secret revocation, generated-user cleanup, and dependents blocking.

**AI assistance:** implementation, unit tests, and documentation were drafted with AI assistance, including locating the lib-bucket-provisioner secret-creation constraint and the change sites across the operator.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
