### PR TITLE
object: support bucket placement for OBC bucket provisioning

### DIFF
--- a/Documentation/Helm-Charts/operator-chart.md
+++ b/Documentation/Helm-Charts/operator-chart.md
@@ -96,7 +96,7 @@ The following table lists the configurable parameters of the rook-operator chart
 | `monRunAsRoot` | If true, ceph mon pods will be run as root | `false` |
 | `monitoring.enabled` | Enable monitoring. Requires Prometheus to be pre-installed. Enabling will also create RBAC rules to allow Operator to create ServiceMonitors | `false` |
 | `nodeSelector` | Kubernetes [`nodeSelector`](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) to add to the Deployment. | `{}` |
-| `obcAllowAdditionalConfigFields` | Many OBC additional config fields may be risky for administrators to allow users control over. The safe and default-allowed fields are 'maxObjects' and 'maxSize'. Other fields should be considered risky. To allow all additional configs, use this value:   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner" | "maxObjects,maxSize" |
+| `obcAllowAdditionalConfigFields` | Many OBC additional config fields may be risky for administrators to allow users control over. The safe and default-allowed fields are 'maxObjects' and 'maxSize'. Other fields should be considered risky. To allow all additional configs, use this value:   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner,locationConstraint,bucketStorageClass" | "maxObjects,maxSize" |
 | `obcProvisionerNamePrefix` | Specify the prefix for the OBC provisioner in place of the cluster namespace | `ceph cluster namespace` |
 | `operatorPodLabels` | Custom pod labels for the operator | `{}` |
 | `priorityClassName` | Set the priority class for the rook operator deployment if desired | `nil` |

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md
@@ -76,6 +76,8 @@ spec:
         ]
       }
     bucketOwner: "rgw-user"
+    locationConstraint: "my-store:europe"
+    bucketStorageClass: "REDUCED_REDUNDANCY"
 ```
 
 1. `name` of the `ObjectBucketClaim`. This name becomes the name of the Secret and ConfigMap.
@@ -96,6 +98,8 @@ If both `bucketName` and `generateBucketName` are blank or omitted then the stor
     * `bucketPolicy`: (disabled by default) A raw JSON format string that defines an AWS S3 format the bucket policy. If set, the policy string will override any existing policy set on the bucket and any default bucket policy that the bucket provisioner potentially would have automatically generated.
     * `bucketLifecycle`: (disabled by default) A raw JSON format string that defines an AWS S3 format bucket lifecycle configuration. Note that the rules must be sorted by `ID` in order to be idempotent.
     * `bucketOwner`: (disabled by default)  The name of a pre-existing ceph rgw user account that will own the bucket. A `CephObjectStoreUser` resource may be used to create an ceph rgw user account. If the bucket already exists and is owned by a different user, the bucket will be re-linked to the specified user.
+    * `locationConstraint`: (disabled by default) The bucket location/placement to request when the provisioner creates the bucket. The value is passed verbatim to RGW as the S3 `CreateBucket` `LocationConstraint`, which RGW interprets as `<zonegroup>[:<placement-target>]` (for example `my-store:europe`, or `:europe` for a placement target in the local zonegroup). Invalid values cause bucket creation to fail. The value only applies when a new bucket is created: if the bucket already exists (a brownfield bucket, or a bucket re-linked via `bucketOwner`), the value is ignored and the operator logs the bucket's existing placement, as RGW bucket placement cannot be changed after creation. When set, this overrides the `locationConstraint` parameter of the StorageClass. Placement targets are configured on the `CephObjectStore` via [pool placements](object-storage.md#create-local-object-stores-with-pool-placements) or externally via `radosgw-admin`.
+    * `bucketStorageClass`: (disabled by default) The default storage class for objects in the bucket, one of the storage classes of the bucket's placement target. The value is sent to RGW as the `X-Amz-Storage-Class` header when the bucket is created (the `LocationConstraint` cannot carry a storage class) and is recorded as the storage class of the bucket's placement rule, shown as `<placement-target>/<storage-class>` in bucket info. Objects written without an explicit `X-Amz-Storage-Class` use it. Like `locationConstraint`, it only applies when a new bucket is created, is ignored (with an operator log) when the bucket already exists, and when set overrides the `bucketStorageClass` parameter of the StorageClass. Storage classes are configured per placement via the `CephObjectStore` [pool placements](object-storage.md#create-local-object-stores-with-pool-placements) (every placement also has `STANDARD`).
 
 Several OBC `additionalConfig` fields are disabled by default. Default-disabled additional config
 fields may be risky for administrators to allow users control over, and they should be enabled only
@@ -178,15 +182,19 @@ parameters: [3]
   objectStoreName: my-store
   objectStoreNamespace: rook-ceph
   bucketName: ceph-bucket [4]
-reclaimPolicy: Delete [5]
+  locationConstraint: my-store:europe [5]
+  bucketStorageClass: REDUCED_REDUNDANCY [6]
+reclaimPolicy: Delete [7]
 ```
 
 1. `label`(optional) here associates this `StorageClass` to a specific provisioner.
 2. `provisioner` responsible for handling `OBCs` referencing this `StorageClass`.
-3. **all** `parameter` required.
+3. `objectStoreName` and `objectStoreNamespace` `parameters` are required; `bucketName`, `locationConstraint`, and `bucketStorageClass` are optional.
 4. `bucketName` is required for access to existing buckets but is omitted when provisioning new buckets.
     Unlike greenfield provisioning, the brownfield bucket name appears in the `StorageClass`, not the `OBC`.
-5. rook-ceph provisioner decides how to treat the `reclaimPolicy` when an `OBC` is deleted for the bucket. See explanation as [specified in Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain)
+5. `locationConstraint`(optional) is the default bucket location/placement requested for buckets provisioned with this class, in the RGW `<zonegroup>[:<placement-target>]` form. An OBC `additionalConfig.locationConstraint` (when allowed) overrides it. It only applies when a new bucket is created; for an existing bucket it is ignored and the operator logs the bucket's actual placement. See the `additionalConfig.locationConstraint` description above.
+6. `bucketStorageClass`(optional) is the default storage class for objects in buckets provisioned with this class, from the placement target's storage classes. An OBC `additionalConfig.bucketStorageClass` (when allowed) overrides it. It only applies when a new bucket is created. See the `additionalConfig.bucketStorageClass` description above.
+7. rook-ceph provisioner decides how to treat the `reclaimPolicy` when an `OBC` is deleted for the bucket. See explanation as [specified in Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain)
 
     * _Delete_ = physically delete the bucket.
     * _Retain_ = do not physically delete the bucket.

--- a/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
+++ b/Documentation/Storage-Configuration/Object-Storage-RGW/object-storage.md
@@ -274,6 +274,10 @@ s5cmd put obj s3://bucket2/obj --storage-class=REDUCED_REDUNDANCY
 
 ```
 
+Buckets provisioned through [ObjectBucketClaims](ceph-object-bucket-claim.md) can also select a
+placement and a default storage class with the `locationConstraint` and `bucketStorageClass`
+StorageClass parameters or OBC `additionalConfig` fields (the OBC fields are disabled by default).
+
 ### Connect to an External Object Store
 
 Rook can connect to existing RGW gateways to work in conjunction with the external mode of the `CephCluster` CRD. First, create a `rgw-admin-ops-user` user in the Ceph cluster with the necessary caps:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -7,3 +7,4 @@
 ## Features
 
 - RBD QoS (Quality of Service) support via `VolumeAttributesClass` using the krbd mounter with cgroup v2 `io.max` enforcement. See the [RBD QoS documentation](Documentation/Storage-Configuration/Block-Storage-RBD/rbd-qos.md) for details.
+- Object: buckets provisioned via ObjectBucketClaim can request a bucket location/placement and a default storage class with the `locationConstraint` and `bucketStorageClass` StorageClass parameters or OBC `additionalConfig` fields (the OBC fields are disabled by default). The values are passed to RGW as the S3 CreateBucket `LocationConstraint` and the `X-Amz-Storage-Class` header.

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -230,7 +230,7 @@ obcProvisionerNamePrefix:
 # -- Many OBC additional config fields may be risky for administrators to allow users control over.
 # The safe and default-allowed fields are 'maxObjects' and 'maxSize'.
 # Other fields should be considered risky. To allow all additional configs, use this value:
-#   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
+#   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner,locationConstraint,bucketStorageClass"
 # @default -- "maxObjects,maxSize"
 obcAllowAdditionalConfigFields: "maxObjects,maxSize"
 

--- a/deploy/examples/storageclass-bucket-delete.yaml
+++ b/deploy/examples/storageclass-bucket-delete.yaml
@@ -14,3 +14,11 @@ parameters:
   # access to the bucket by creating a new user, attaching it to the bucket, and
   # providing the credentials via a Secret in the namespace of the requesting OBC.
   #bucketName:
+  # To request a bucket location/placement for newly provisioned buckets, set the
+  # RGW location constraint ("<zonegroup>[:<placement-target>]"). Ignored for
+  # existing buckets; bucket placement cannot be changed after creation.
+  #locationConstraint:
+  # To set the default storage class for objects in newly provisioned buckets,
+  # name one of the placement target's storage classes. Ignored for existing
+  # buckets.
+  #bucketStorageClass:

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -65,13 +65,15 @@ type Provisioner struct {
 }
 
 type additionalConfigSpec struct {
-	maxObjects       *int64
-	maxSize          *int64
-	bucketMaxObjects *int64
-	bucketMaxSize    *int64
-	bucketPolicy     *string
-	bucketLifecycle  *string
-	bucketOwner      *string
+	maxObjects         *int64
+	maxSize            *int64
+	bucketMaxObjects   *int64
+	bucketMaxSize      *int64
+	bucketPolicy       *string
+	bucketLifecycle    *string
+	bucketOwner        *string
+	locationConstraint *string
+	bucketStorageClass *string
 }
 
 var _ apibkt.Provisioner = &Provisioner{}
@@ -120,9 +122,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	}
 
 	// create the bucket
-	var bucketExists bool
-	var owner string
-	bucketExists, owner, err = p.bucketExists(p.bucketName)
+	bucketExists, bucketInfo, err := p.bucketExists(p.bucketName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating bucket %q. failed to check if bucket already exists", p.bucketName)
 	}
@@ -130,19 +130,22 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		// if bucket already exists, this returns error: TooManyBuckets because we set the quota
 		// below. If it already exists, assume we are good to go
 		log.NamedDebug(nsName, logger, "creating bucket %q owned by user %q", p.bucketName, p.cephUserName)
-		err = p.s3Agent.CreateBucket(p.clusterInfo.Context, p.bucketName)
+		err = p.s3Agent.CreateBucketWithPlacement(p.clusterInfo.Context, p.bucketName, bucket.locationConstraint, bucket.bucketStorageClass)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating bucket %q", p.bucketName)
 		}
-	} else if owner != p.cephUserName {
-		log.NamedDebug(nsName, logger, "bucket %q already exists and is owned by user %q instead of user %q, relinking...", p.bucketName, owner, p.cephUserName)
-
-		err = p.adminOpsClient.LinkBucket(p.clusterInfo.Context, admin.BucketLinkInput{Bucket: p.bucketName, UID: p.cephUserName})
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to link bucket %q to user %q", p.bucketName, p.cephUserName)
-		}
 	} else {
-		log.NamedDebug(nsName, logger, "bucket %q already exists", p.bucketName)
+		p.logIgnoredPlacement(bucketInfo, bucket)
+		if bucketInfo.Owner != p.cephUserName {
+			log.NamedDebug(nsName, logger, "bucket %q already exists and is owned by user %q instead of user %q, relinking...", p.bucketName, bucketInfo.Owner, p.cephUserName)
+
+			err = p.adminOpsClient.LinkBucket(p.clusterInfo.Context, admin.BucketLinkInput{Bucket: p.bucketName, UID: p.cephUserName})
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to link bucket %q to user %q", p.bucketName, p.cephUserName)
+			}
+		} else {
+			log.NamedDebug(nsName, logger, "bucket %q already exists", p.bucketName)
+		}
 	}
 
 	// is the bucket owner a provisioner generated user?
@@ -186,9 +189,11 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 
 	// check and make sure the bucket exists
 	log.NamedInfo(nsName, logger, "Checking for existing bucket %q", p.bucketName)
-	if exists, _, err := p.bucketExists(p.bucketName); !exists {
+	exists, bucketInfo, err := p.bucketExists(p.bucketName)
+	if !exists {
 		return nil, errors.Wrapf(err, "bucket %s does not exist", p.bucketName)
 	}
+	p.logIgnoredPlacement(bucketInfo, bucket)
 
 	p.accessKeyID, p.secretAccessKey, err = bucket.getUserCreds()
 	if err != nil {
@@ -443,6 +448,16 @@ func (p *Provisioner) initializeCreateOrGrant(bucket *bucket) error {
 	}
 	log.NamedDebug(nsName, logger, "Using user %q for OBC %q", p.cephUserName, obc.Name)
 
+	// the OBC additionalConfig values override the StorageClass parameters
+	bucket.locationConstraint = getLocationConstraint(sc, bucket.additionalConfig)
+	if bucket.locationConstraint != "" {
+		log.NamedDebug(nsName, logger, "Using location constraint %q for OBC %q", bucket.locationConstraint, obc.Name)
+	}
+	bucket.bucketStorageClass = getBucketStorageClass(sc, bucket.additionalConfig)
+	if bucket.bucketStorageClass != "" {
+		log.NamedDebug(nsName, logger, "Using default storage class %q for OBC %q", bucket.bucketStorageClass, obc.Name)
+	}
+
 	return nil
 }
 
@@ -524,6 +539,25 @@ func (p *Provisioner) composeObjectBucket(bucket *bucket) *bktv1alpha1.ObjectBuc
 			Connection: conn,
 		},
 	}
+}
+
+// logIgnoredPlacement notes a requested locationConstraint and/or
+// bucketStorageClass that was not applied because the bucket already exists;
+// RGW bucket placement is immutable after creation.
+func (p *Provisioner) logIgnoredPlacement(bucketInfo *admin.Bucket, bucket *bucket) {
+	requested := []string{}
+	if bucket.locationConstraint != "" {
+		requested = append(requested, fmt.Sprintf("locationConstraint %q", bucket.locationConstraint))
+	}
+	if bucket.bucketStorageClass != "" {
+		requested = append(requested, fmt.Sprintf("bucketStorageClass %q", bucket.bucketStorageClass))
+	}
+	if len(requested) == 0 {
+		return
+	}
+	log.NamedInfo(p.objectContext.NsName(), logger,
+		"bucket %q already exists with placement %q, ignoring requested %s (bucket placement cannot be changed after creation)",
+		bucketInfo.Bucket, bucketInfo.PlacementRule, strings.Join(requested, " and "))
 }
 
 func (p *Provisioner) setObjectContext() error {

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -590,10 +590,32 @@ func TestProvisioner_additionalConfigSpecFromMap(t *testing.T) {
 		assert.Equal(t, additionalConfigSpec{bucketOwner: &(&struct{ s string }{"foo"}).s}, *spec)
 	})
 
+	t.Run("locationConstraint field should be set", func(t *testing.T) {
+		os.Setenv("ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS", "locationConstraint")
+		defer os.Unsetenv("ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS")
+		opcontroller.SetObcAllowAdditionalConfigFields()
+		defer opcontroller.SetObcAllowAdditionalConfigFields()
+
+		spec, err := additionalConfigSpecFromMap(map[string]string{"locationConstraint": "my-store:fast"})
+		assert.NoError(t, err)
+		assert.Equal(t, additionalConfigSpec{locationConstraint: &(&struct{ s string }{"my-store:fast"}).s}, *spec)
+	})
+
+	t.Run("bucketStorageClass field should be set", func(t *testing.T) {
+		os.Setenv("ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS", "bucketStorageClass")
+		defer os.Unsetenv("ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS")
+		opcontroller.SetObcAllowAdditionalConfigFields()
+		defer opcontroller.SetObcAllowAdditionalConfigFields()
+
+		spec, err := additionalConfigSpecFromMap(map[string]string{"bucketStorageClass": "FOO"})
+		assert.NoError(t, err)
+		assert.Equal(t, additionalConfigSpec{bucketStorageClass: &(&struct{ s string }{"FOO"}).s}, *spec)
+	})
+
 	t.Run("fields disallowed by default", func(t *testing.T) {
 		opcontroller.SetObcAllowAdditionalConfigFields()
 
-		for _, configKey := range []string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner"} {
+		for _, configKey := range []string{"bucketMaxObjects", "bucketMaxSize", "bucketPolicy", "bucketLifecycle", "bucketOwner", "locationConstraint", "bucketStorageClass"} {
 			_, err := additionalConfigSpecFromMap(map[string]string{configKey: "foo"})
 			assert.Error(t, err)
 		}
@@ -605,6 +627,70 @@ func TestProvisioner_additionalConfigSpecFromMap(t *testing.T) {
 		spec, err := additionalConfigSpecFromMap(map[string]string{})
 		assert.NoError(t, err)
 		assert.Equal(t, additionalConfigSpec{}, *spec)
+	})
+}
+
+func TestGetLocationConstraint(t *testing.T) {
+	scWith := func(params map[string]string) *storagev1.StorageClass {
+		return &storagev1.StorageClass{Parameters: params}
+	}
+
+	t.Run("neither set", func(t *testing.T) {
+		assert.Equal(t, "", getLocationConstraint(scWith(nil), &additionalConfigSpec{}))
+	})
+
+	t.Run("StorageClass parameter only", func(t *testing.T) {
+		sc := scWith(map[string]string{"locationConstraint": "my-store:fast"})
+		assert.Equal(t, "my-store:fast", getLocationConstraint(sc, &additionalConfigSpec{}))
+	})
+
+	t.Run("OBC additionalConfig only", func(t *testing.T) {
+		loc := ":fast"
+		assert.Equal(t, ":fast", getLocationConstraint(scWith(nil), &additionalConfigSpec{locationConstraint: &loc}))
+	})
+
+	t.Run("OBC additionalConfig overrides StorageClass parameter", func(t *testing.T) {
+		sc := scWith(map[string]string{"locationConstraint": "my-store:us"})
+		loc := "my-store:eu"
+		assert.Equal(t, "my-store:eu", getLocationConstraint(sc, &additionalConfigSpec{locationConstraint: &loc}))
+	})
+
+	t.Run("empty OBC value overrides StorageClass parameter to unset", func(t *testing.T) {
+		sc := scWith(map[string]string{"locationConstraint": "my-store:us"})
+		loc := ""
+		assert.Equal(t, "", getLocationConstraint(sc, &additionalConfigSpec{locationConstraint: &loc}))
+	})
+}
+
+func TestGetBucketStorageClass(t *testing.T) {
+	scWith := func(params map[string]string) *storagev1.StorageClass {
+		return &storagev1.StorageClass{Parameters: params}
+	}
+
+	t.Run("neither set", func(t *testing.T) {
+		assert.Equal(t, "", getBucketStorageClass(scWith(nil), &additionalConfigSpec{}))
+	})
+
+	t.Run("StorageClass parameter only", func(t *testing.T) {
+		sc := scWith(map[string]string{"bucketStorageClass": "FOO"})
+		assert.Equal(t, "FOO", getBucketStorageClass(sc, &additionalConfigSpec{}))
+	})
+
+	t.Run("OBC additionalConfig only", func(t *testing.T) {
+		class := "FOO"
+		assert.Equal(t, "FOO", getBucketStorageClass(scWith(nil), &additionalConfigSpec{bucketStorageClass: &class}))
+	})
+
+	t.Run("OBC additionalConfig overrides StorageClass parameter", func(t *testing.T) {
+		sc := scWith(map[string]string{"bucketStorageClass": "FOO"})
+		class := "BAR"
+		assert.Equal(t, "BAR", getBucketStorageClass(sc, &additionalConfigSpec{bucketStorageClass: &class}))
+	})
+
+	t.Run("empty OBC value overrides StorageClass parameter to unset", func(t *testing.T) {
+		sc := scWith(map[string]string{"bucketStorageClass": "FOO"})
+		class := ""
+		assert.Equal(t, "", getBucketStorageClass(sc, &additionalConfigSpec{bucketStorageClass: &class}))
 	})
 }
 

--- a/pkg/operator/ceph/object/bucket/rgw-handlers.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers.go
@@ -21,6 +21,13 @@ type bucket struct {
 	provisioner      *Provisioner
 	options          *apibkt.BucketOptions
 	additionalConfig *additionalConfigSpec
+	// locationConstraint and bucketStorageClass are the effective location
+	// constraint and default storage class for greenfield bucket creation
+	// (the OBC additionalConfig values, falling back to the StorageClass
+	// parameters); empty when not requested. They are passed to RGW verbatim
+	// and only apply when the provisioner creates the bucket.
+	locationConstraint string
+	bucketStorageClass string
 }
 
 // Retrieve the s3 access credentials for the rgw user.  The rgw user will be
@@ -50,15 +57,17 @@ func (b *bucket) getUserCreds() (accessKeyID, secretAccessKey string, err error)
 	return
 }
 
-func (p *Provisioner) bucketExists(name string) (bool, string, error) {
+// bucketExists returns whether the named bucket exists, and its bucket info
+// (owner, placement rule, etc.) when it does.
+func (p *Provisioner) bucketExists(name string) (bool, *admin.Bucket, error) {
 	bucket, err := p.adminOpsClient.GetBucketInfo(p.clusterInfo.Context, admin.Bucket{Bucket: name})
 	if err != nil {
 		if errors.Is(err, admin.ErrNoSuchBucket) {
-			return false, "", nil
+			return false, nil, nil
 		}
-		return false, "", errors.Wrapf(err, "failed to get ceph bucket %q", name)
+		return false, nil, errors.Wrapf(err, "failed to get ceph bucket %q", name)
 	}
-	return true, bucket.Owner, nil
+	return true, &bucket, nil
 }
 
 // Create a Ceph user based on the passed-in name or a generated name. Return the

--- a/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
@@ -93,6 +93,57 @@ func TestDeleteBucket(t *testing.T) {
 	})
 }
 
+func TestBucketExists(t *testing.T) {
+	clusterInfo := client.AdminTestClusterInfo("ns")
+	p := NewProvisioner(&clusterd.Context{RookClientset: rookclient.NewSimpleClientset(), Clientset: test.New(t, 1)}, clusterInfo)
+	mockClient := func(statusCode int, body string) *cephobject.MockClient {
+		return &cephobject.MockClient{
+			MockDo: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "rook-ceph-rgw-my-store.mycluster.svc/admin/bucket" && req.Method == http.MethodGet {
+					return &http.Response{
+						StatusCode: statusCode,
+						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				}
+				return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)
+			},
+		}
+	}
+
+	t.Run("bucket exists", func(t *testing.T) {
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(200, `{"bucket":"bkt","owner":"bob","placement_rule":"loc-a"}`))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		exists, info, err := p.bucketExists("bkt")
+		assert.NoError(t, err)
+		assert.True(t, exists)
+		assert.Equal(t, "bob", info.Owner)
+		assert.Equal(t, "loc-a", info.PlacementRule)
+	})
+
+	t.Run("bucket does not exist", func(t *testing.T) {
+		status, _ := json.Marshal(statusError{"NoSuchBucket", "requestid", "hostid"})
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(404, string(status)))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		exists, info, err := p.bucketExists("bkt")
+		assert.NoError(t, err)
+		assert.False(t, exists)
+		assert.Nil(t, info)
+	})
+
+	t.Run("error other than NoSuchBucket", func(t *testing.T) {
+		status, _ := json.Marshal(statusError{"AccessDenied", "requestid", "hostid"})
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(403, string(status)))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		exists, info, err := p.bucketExists("bkt")
+		assert.Error(t, err)
+		assert.False(t, exists)
+		assert.Nil(t, info)
+	})
+}
+
 func TestIsObcGeneratedUser(t *testing.T) {
 	clusterInfo := client.AdminTestClusterInfo("ns")
 	p := NewProvisioner(&clusterd.Context{RookClientset: rookclient.NewSimpleClientset(), Clientset: test.New(t, 1)}, clusterInfo)

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -42,6 +42,11 @@ const (
 	ObjectStoreName      = "objectStoreName"
 	ObjectStoreNamespace = "objectStoreNamespace"
 	objectStoreEndpoint  = "endpoint"
+	// locationConstraintKey and bucketStorageClassKey are each both a
+	// StorageClass parameter and an OBC additionalConfig key; the OBC value
+	// overrides the StorageClass value.
+	locationConstraintKey = "locationConstraint"
+	bucketStorageClassKey = "bucketStorageClass"
 )
 
 func NewBucketController(cfg *rest.Config, p *Provisioner) (*provisioner.Provisioner, error) {
@@ -71,6 +76,28 @@ func isStaticBucket(sc *storagev1.StorageClass) (string, bool) {
 	const key = "bucketName"
 	val, ok := sc.Parameters[key]
 	return val, ok
+}
+
+// getLocationConstraint returns the effective location constraint for
+// greenfield bucket creation: the OBC additionalConfig value, when set,
+// overrides the StorageClass parameter. Empty means no constraint was
+// requested.
+func getLocationConstraint(sc *storagev1.StorageClass, additionalConfig *additionalConfigSpec) string {
+	if additionalConfig.locationConstraint != nil {
+		return *additionalConfig.locationConstraint
+	}
+	return sc.Parameters[locationConstraintKey]
+}
+
+// getBucketStorageClass returns the effective default storage class for
+// greenfield bucket creation: the OBC additionalConfig value, when set,
+// overrides the StorageClass parameter. Empty means no storage class was
+// requested.
+func getBucketStorageClass(sc *storagev1.StorageClass, additionalConfig *additionalConfigSpec) string {
+	if additionalConfig.bucketStorageClass != nil {
+		return *additionalConfig.bucketStorageClass
+	}
+	return sc.Parameters[bucketStorageClassKey]
 }
 
 func getCephUser(ob *bktv1alpha1.ObjectBucket) string {
@@ -156,6 +183,22 @@ func additionalConfigSpecFromMap(config map[string]string) (*additionalConfigSpe
 		}
 		bucketOwner := config["bucketOwner"]
 		spec.bucketOwner = &bucketOwner
+	}
+
+	if _, ok := config[locationConstraintKey]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed(locationConstraintKey) {
+			return nil, errors.Errorf("OBC config %q is not allowed", locationConstraintKey)
+		}
+		location := config[locationConstraintKey]
+		spec.locationConstraint = &location
+	}
+
+	if _, ok := config[bucketStorageClassKey]; ok {
+		if !opcontroller.ObcAdditionalConfigKeyIsAllowed(bucketStorageClassKey) {
+			return nil, errors.Errorf("OBC config %q is not allowed", bucketStorageClassKey)
+		}
+		storageClass := config[bucketStorageClassKey]
+		spec.bucketStorageClass = &storageClass
 	}
 
 	return &spec, nil

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithylogging "github.com/aws/smithy-go/logging"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/pkg/errors"
 )
 
@@ -97,21 +99,52 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 
 // CreateBucket creates a bucket with the given name
 func (s *S3Agent) CreateBucket(ctx context.Context, name string) error {
-	return s.createBucket(ctx, name, true)
+	return s.createBucket(ctx, name, "", "", true)
 }
 
-func (s *S3Agent) createBucket(ctx context.Context, name string, infoLogging bool) error {
+// CreateBucketWithPlacement creates a bucket with the given name, an optional
+// location constraint, and an optional default storage class. The location is
+// passed to RGW verbatim as the S3 CreateBucketConfiguration.LocationConstraint,
+// which RGW interprets as "<zonegroup>[:<placement-target>]". The storage
+// class is passed as the X-Amz-Storage-Class request header, which RGW records
+// as the storage class of the bucket's placement rule. With both values empty
+// this is equivalent to CreateBucket.
+func (s *S3Agent) CreateBucketWithPlacement(ctx context.Context, name, location, storageClass string) error {
+	return s.createBucket(ctx, name, location, storageClass, true)
+}
+
+func (s *S3Agent) createBucket(ctx context.Context, name, location, storageClass string, infoLogging bool) error {
+	msg := fmt.Sprintf("creating bucket %q", name)
+	if location != "" {
+		msg += fmt.Sprintf(" with location constraint %q", location)
+	}
+	if storageClass != "" {
+		msg += fmt.Sprintf(" with default storage class %q", storageClass)
+	}
 	if infoLogging {
-		logger.Infof("creating bucket %q", name)
+		logger.Info(msg)
 	} else {
-		logger.Debugf("creating bucket %q", name)
+		logger.Debug(msg)
 	}
 
 	input := &s3.CreateBucketInput{
 		Bucket: &name,
 	}
+	if location != "" {
+		input.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(location),
+		}
+	}
+	var optFns []func(*s3.Options)
+	if storageClass != "" {
+		// CreateBucketInput has no storage class field; a bucket default
+		// storage class is an RGW extension read from this request header
+		optFns = append(optFns, func(o *s3.Options) {
+			o.APIOptions = append(o.APIOptions, smithyhttp.SetHeaderValue("X-Amz-Storage-Class", storageClass))
+		})
+	}
 
-	_, err := s.Client.CreateBucket(ctx, input)
+	_, err := s.Client.CreateBucket(ctx, input, optFns...)
 	if err != nil {
 		var alreadyExists *s3types.BucketAlreadyExists
 		var alreadyOwned *s3types.BucketAlreadyOwnedByYou

--- a/pkg/operator/ceph/object/s3-handlers_test.go
+++ b/pkg/operator/ceph/object/s3-handlers_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package object
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -119,5 +122,75 @@ func TestNewS3Agent(t *testing.T) {
 		s3Agent, err := NewS3Agent(accessKey, secretKey, ep, false, nil, true, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "https://rook-ceph-rgw-store.test-ns.svc:443", *s3Agent.Client.Options().BaseEndpoint)
+	})
+}
+
+type capturingRoundTripper struct {
+	req  *http.Request
+	body []byte
+}
+
+func (rt *capturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.req = req
+	if req.Body != nil {
+		rt.body, _ = io.ReadAll(req.Body)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestS3AgentCreateBucket(t *testing.T) {
+	newAgent := func(t *testing.T, rt http.RoundTripper) *S3Agent {
+		s3Agent, err := NewS3Agent("accessKey", "secretKey", "endpoint", false, nil, false, &http.Client{Transport: rt})
+		assert.NoError(t, err)
+		return s3Agent
+	}
+
+	t.Run("CreateBucket sends no CreateBucketConfiguration", func(t *testing.T) {
+		rt := &capturingRoundTripper{}
+		err := newAgent(t, rt).CreateBucket(context.TODO(), "bkt")
+		assert.NoError(t, err)
+		assert.Equal(t, http.MethodPut, rt.req.Method)
+		assert.Contains(t, rt.req.URL.Path, "/bkt")
+		assert.NotContains(t, string(rt.body), "CreateBucketConfiguration")
+	})
+
+	t.Run("CreateBucketWithPlacement sends the location verbatim", func(t *testing.T) {
+		rt := &capturingRoundTripper{}
+		err := newAgent(t, rt).CreateBucketWithPlacement(context.TODO(), "bkt", "my-store:loc-a", "")
+		assert.NoError(t, err)
+		assert.Equal(t, http.MethodPut, rt.req.Method)
+		assert.Contains(t, rt.req.URL.Path, "/bkt")
+		assert.Contains(t, string(rt.body), "<LocationConstraint>my-store:loc-a</LocationConstraint>")
+		assert.Empty(t, rt.req.Header.Get("X-Amz-Storage-Class"))
+	})
+
+	t.Run("CreateBucketWithPlacement sends the storage class header", func(t *testing.T) {
+		rt := &capturingRoundTripper{}
+		err := newAgent(t, rt).CreateBucketWithPlacement(context.TODO(), "bkt", "my-store:loc-a", "FOO")
+		assert.NoError(t, err)
+		assert.Contains(t, string(rt.body), "<LocationConstraint>my-store:loc-a</LocationConstraint>")
+		assert.Equal(t, "FOO", rt.req.Header.Get("X-Amz-Storage-Class"))
+		// the header must be part of the SigV4 signature or RGW rejects it
+		assert.Contains(t, rt.req.Header.Get("Authorization"), "x-amz-storage-class")
+	})
+
+	t.Run("storage class header without a location constraint", func(t *testing.T) {
+		rt := &capturingRoundTripper{}
+		err := newAgent(t, rt).CreateBucketWithPlacement(context.TODO(), "bkt", "", "FOO")
+		assert.NoError(t, err)
+		assert.NotContains(t, string(rt.body), "CreateBucketConfiguration")
+		assert.Equal(t, "FOO", rt.req.Header.Get("X-Amz-Storage-Class"))
+	})
+
+	t.Run("empty location and storage class behave like CreateBucket", func(t *testing.T) {
+		rt := &capturingRoundTripper{}
+		err := newAgent(t, rt).CreateBucketWithPlacement(context.TODO(), "bkt", "", "")
+		assert.NoError(t, err)
+		assert.NotContains(t, string(rt.body), "CreateBucketConfiguration")
+		assert.Empty(t, rt.req.Header.Get("X-Amz-Storage-Class"))
 	})
 }

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -99,7 +99,7 @@ func (s *TestCephSettings) replaceOperatorSettings(manifest string) string {
 	manifest = strings.ReplaceAll(manifest, `CSI_ENABLE_VOLUME_REPLICATION: "false"`, fmt.Sprintf(`CSI_ENABLE_VOLUME_REPLICATION: "%t"`, s.EnableVolumeReplication))
 	manifest = strings.ReplaceAll(manifest,
 		`# ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs`,
-		`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"`)
+		`ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner,locationConstraint,bucketStorageClass"`)
 	if s.ClusterConcurrency > 1 {
 		manifest = strings.ReplaceAll(manifest, `ROOK_RECONCILE_CONCURRENT_CLUSTERS: "1"`, fmt.Sprintf(`ROOK_RECONCILE_CONCURRENT_CLUSTERS: "%d"`, s.ClusterConcurrency))
 	}

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	bucketlocation "github.com/rook/rook/tests/integration/object/bucket/location"
 	bucketowner "github.com/rook/rook/tests/integration/object/bucket/owner"
 	bucketpolicy "github.com/rook/rook/tests/integration/object/bucket/policy"
 	bucketquota "github.com/rook/rook/tests/integration/object/bucket/quota"
@@ -215,6 +216,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	testObjectStoreOperations(s, helper, k8sh, settings, storeName, swiftAndKeystone)
 
 	sharedObjectStore := sharedstore.Create(s.T(), k8sh, installer, tlsEnable, settings.Namespace, "sharedstore", 1,
+		bucketlocation.Namespace,
 		bucketowner.Namespace,
 		bucketpolicy.Namespace,
 		bucketquota.Namespace,
@@ -228,6 +230,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, install
 	)
 	defer sharedObjectStore.Destroy()
 
+	bucketlocation.TestObjectBucketClaimLocationConstraint(s.T(), k8sh, sharedObjectStore)
 	bucketowner.TestObjectBucketClaimBucketOwner(s.T(), k8sh, sharedObjectStore)
 	bucketpolicy.TestObjectBucketClaimPolicy(s.T(), k8sh, sharedObjectStore)
 	bucketquota.TestObjectBucketClaimQuota(s.T(), k8sh, sharedObjectStore)

--- a/tests/integration/object/README.md
+++ b/tests/integration/object/README.md
@@ -32,6 +32,7 @@ must not collide with std-lib package names (no `io`, no `http`).
 
 | test package | operator package | covers |
 |---|---|---|
+| `bucket/location` | `object/bucket` | OBC/SC `locationConstraint`/`bucketStorageClass` bucket placement |
 | `bucket/owner` | `object/bucket` | OBC `bucketOwner` handling |
 | `bucket/policy` | `object/bucket` | OBC bucketPolicy management |
 | `bucket/quota` | `object/bucket` | OBC maxObjects user quota + bucketMaxObjects/bucketMaxSize bucket quota |

--- a/tests/integration/object/bucket/location/location.go
+++ b/tests/integration/object/bucket/location/location.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2026 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package location covers OBC/StorageClass locationConstraint handling: bucket
+// placement selection at greenfield creation, OBC-over-SC precedence, and the
+// ignored-constraint logging for existing buckets.
+package location
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/rook/rook/tests/integration/object/util/fixture"
+	"github.com/rook/rook/tests/integration/object/util/obc"
+	"github.com/rook/rook/tests/integration/object/util/sharedstore"
+	"github.com/rook/rook/tests/integration/object/util/wait4"
+)
+
+const Namespace = "test-bucketlocation"
+
+func TestObjectBucketClaimLocationConstraint(t *testing.T, k8sh *utils.K8sHelper, store *sharedstore.Sharedstore) {
+	var (
+		defaultName = Namespace
+		objectStore = store.ObjectStore()
+		adminClient = store.AdminClient()
+
+		// the zonegroup is named after the store; the RGW LocationConstraint
+		// format is "<zonegroup>[:<placement-target>]"
+		placementFQ = objectStore.Name + ":" + sharedstore.PlacementLocA
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultName,
+			},
+		}
+
+		// no locationConstraint parameter
+		scPlain = obc.StorageClass(defaultName+"-plain", objectStore)
+
+		// carries an admin-default locationConstraint
+		scLoc = obc.StorageClass(defaultName+"-loc", objectStore)
+
+		// brownfield class granting access to obcScLoc's bucket; its
+		// locationConstraint must be ignored
+		scBrown = obc.StorageClass(defaultName+"-brown", objectStore)
+
+		obcScLoc = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-sc-loc",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-sc-loc",
+				StorageClassName: scLoc.Name,
+			},
+		}
+
+		// the ":<placement-target>" short form selects a placement in the
+		// local zonegroup
+		obcObcLoc = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-obc-loc",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-obc-loc",
+				StorageClassName: scPlain.Name,
+				AdditionalConfig: map[string]string{
+					"locationConstraint": ":" + sharedstore.PlacementLocA,
+				},
+			},
+		}
+
+		obcObcWins = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-obc-wins",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-obc-wins",
+				StorageClassName: scLoc.Name,
+				AdditionalConfig: map[string]string{
+					"locationConstraint": objectStore.Name + ":default",
+				},
+			},
+		}
+
+		obcDefault = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-default",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-default",
+				StorageClassName: scPlain.Name,
+			},
+		}
+
+		// the "FOO" storage class is defined on the shared store's "default"
+		// placement
+		obcFoo = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-foo",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-foo",
+				StorageClassName: scPlain.Name,
+				AdditionalConfig: map[string]string{
+					"locationConstraint": objectStore.Name + ":default",
+					"bucketStorageClass": "FOO",
+				},
+			},
+		}
+
+		// brownfield: the bucket name comes from the StorageClass
+		obcBrown = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-brown",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				StorageClassName: scBrown.Name,
+			},
+		}
+
+		obcBogus = bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultName + "-bogus",
+				Namespace: ns.Name,
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				BucketName:       defaultName + "-bogus",
+				StorageClassName: scPlain.Name,
+				AdditionalConfig: map[string]string{
+					"locationConstraint": "bogus:nowhere",
+				},
+			},
+		}
+
+		obcClient        = k8sh.BucketClientset.ObjectbucketV1alpha1().ObjectBucketClaims(ns.Name)
+		operatorSelector = labels.SelectorFromSet(labels.Set{
+			"app": "rook-ceph-operator",
+		})
+	)
+
+	t.Run("OBC locationConstraint", func(t *testing.T) {
+		ctx := t.Context()
+
+		fixture.RequireNamespace(t, k8sh, ns)
+
+		scLoc.Parameters["locationConstraint"] = placementFQ
+		fixture.RequireStorageClass(t, k8sh, scLoc)
+		fixture.RequireStorageClass(t, k8sh, scPlain)
+
+		scBrown.Parameters["bucketName"] = obcScLoc.Spec.BucketName
+		// the ":default" short form is distinct from the re-provision case's
+		// requested value so the log assertions cannot match each other's
+		// lines
+		scBrown.Parameters["locationConstraint"] = ":default"
+		fixture.RequireStorageClass(t, k8sh, scBrown)
+
+		t.Run(fmt.Sprintf("greenfield bucket via SC parameter lands in placement %q", sharedstore.PlacementLocA), func(t *testing.T) {
+			obc.RequireBound(ctx, t, k8sh, &obcScLoc)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcScLoc.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, sharedstore.PlacementLocA, bucket.PlacementRule)
+		})
+
+		t.Run(fmt.Sprintf("greenfield bucket via OBC additionalConfig lands in placement %q", sharedstore.PlacementLocA), func(t *testing.T) {
+			obc.RequireBound(ctx, t, k8sh, &obcObcLoc)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcObcLoc.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, sharedstore.PlacementLocA, bucket.PlacementRule)
+		})
+
+		t.Run("OBC additionalConfig overrides the SC parameter", func(t *testing.T) {
+			obc.RequireBound(ctx, t, k8sh, &obcObcWins)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcObcWins.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, "default", bucket.PlacementRule)
+		})
+
+		t.Run("bucket without locationConstraint lands in the default placement", func(t *testing.T) {
+			obc.RequireBound(ctx, t, k8sh, &obcDefault)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcDefault.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, "default", bucket.PlacementRule)
+		})
+
+		t.Run("bucketStorageClass is recorded in the bucket placement rule", func(t *testing.T) {
+			obc.RequireBound(ctx, t, k8sh, &obcFoo)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcFoo.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, "default/FOO", bucket.PlacementRule)
+		})
+
+		t.Run("locationConstraint is ignored for an existing bucket on re-provision", func(t *testing.T) {
+			requested := objectStore.Name + ":default"
+			obc.Update(ctx, t, k8sh, ns.Name, obcScLoc.Name, func(live *bktv1alpha1.ObjectBucketClaim) {
+				live.Spec.AdditionalConfig = map[string]string{"locationConstraint": requested}
+			})
+
+			wait4.RequirePodLog(ctx, t, k8sh, "object-ns-system", operatorSelector, wait4.TimeoutShort, func(line string) bool {
+				return strings.Contains(line, "ignoring requested locationConstraint") &&
+					strings.Contains(line, fmt.Sprintf("%q", requested)) &&
+					strings.Contains(line, obcScLoc.Spec.BucketName)
+			})
+
+			liveObc, err := obcClient.Get(ctx, obcScLoc.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.True(t, bktv1alpha1.ObjectBucketClaimStatusPhaseBound == liveObc.Status.Phase)
+
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcScLoc.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, sharedstore.PlacementLocA, bucket.PlacementRule)
+		})
+
+		t.Run("brownfield Grant ignores the SC locationConstraint", func(t *testing.T) {
+			bucket, err := adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcScLoc.Spec.BucketName})
+			require.NoError(t, err)
+
+			// Grant manages the bucket policy with the OBC user's own S3
+			// credentials, so a brownfield claim by a user without access to
+			// the bucket cannot bind (GetBucketPolicy fails with AccessDenied);
+			// claim the bucket as its owner instead
+			obcBrown.Spec.AdditionalConfig = map[string]string{"bucketOwner": bucket.Owner}
+
+			obc.RequireBound(ctx, t, k8sh, &obcBrown)
+
+			wait4.RequirePodLog(ctx, t, k8sh, "object-ns-system", operatorSelector, wait4.TimeoutShort, func(line string) bool {
+				return strings.Contains(line, "ignoring requested locationConstraint") &&
+					strings.Contains(line, `":default"`) &&
+					strings.Contains(line, obcScLoc.Spec.BucketName)
+			})
+
+			bucket, err = adminClient.GetBucketInfo(ctx, admin.Bucket{Bucket: obcScLoc.Spec.BucketName})
+			require.NoError(t, err)
+			assert.Equal(t, sharedstore.PlacementLocA, bucket.PlacementRule)
+		})
+
+		// "failure" means the obc remains in Pending state
+		t.Run("invalid locationConstraint fails provisioning", func(t *testing.T) {
+			_, err := obcClient.Create(ctx, &obcBogus, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			// RGW rejects the unknown zonegroup/placement with the
+			// InvalidLocationConstraint api error code
+			wait4.RequirePodLog(ctx, t, k8sh, "object-ns-system", operatorSelector, wait4.TimeoutShort, func(line string) bool {
+				return strings.Contains(line, "InvalidLocationConstraint") &&
+					strings.Contains(line, obcBogus.Spec.BucketName)
+			})
+
+			liveObc, err := obcClient.Get(ctx, obcBogus.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.True(t, bktv1alpha1.ObjectBucketClaimStatusPhasePending == liveObc.Status.Phase)
+		})
+
+		// the brownfield obc goes first: deleting the greenfield obcScLoc
+		// removes the shared bucket
+		for _, name := range []string{obcBrown.Name, obcScLoc.Name, obcObcLoc.Name, obcObcWins.Name, obcDefault.Name, obcFoo.Name, obcBogus.Name} {
+			t.Run(fmt.Sprintf("delete obc %q", name), func(t *testing.T) {
+				obc.DeleteAndWait(ctx, t, k8sh, ns.Name, name)
+			})
+		}
+	})
+}

--- a/tests/integration/object/util/sharedstore/sharedstore.go
+++ b/tests/integration/object/util/sharedstore/sharedstore.go
@@ -40,6 +40,10 @@ import (
 	"github.com/rook/rook/tests/integration/object/util/wait4"
 )
 
+// PlacementLocA is a non-default pool placement defined on the shared store's
+// zone for bucket location/placement tests.
+const PlacementLocA = "loc-a"
+
 type Sharedstore struct {
 	adminClient *admin.API
 	snsClient   *sns.Client
@@ -126,6 +130,13 @@ func Create(t *testing.T, k8sh *utils.K8sHelper, installer *installer.CephInstal
 								DataPoolName: storeName + ".rgw.buckets.data.foo",
 							},
 						},
+					},
+					{
+						// the same shared pools back this placement; RADOS
+						// namespacing keeps its data distinct
+						Name:             PlacementLocA,
+						MetadataPoolName: storeName + ".rgw.buckets.index",
+						DataPoolName:     storeName + ".rgw.buckets.data",
 					},
 				},
 			},


### PR DESCRIPTION
**Experimental** support for selecting the RGW placement of a bucket provisioned for an ObjectBucketClaim, via new `locationConstraint` and `bucketStorageClass` keys, each available on two channels:

- **StorageClass parameter** — admin-set default for all buckets provisioned with that class.
- **OBC `spec.additionalConfig`** — per-claim override; disabled by default behind `ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS` (like `bucketPolicy`/`bucketOwner`). The OBC values override the SC parameters.

The effective `locationConstraint` is passed verbatim to RGW as the S3 CreateBucket `LocationConstraint`, which RGW interprets as `<zonegroup>[:<placement-target>]` (e.g. `my-store:europe`, or `:europe` for a placement target in the local zonegroup). Invalid values fail provisioning with RGW's `InvalidLocationConstraint` and the OBC stays `Pending`.

The effective `bucketStorageClass` is sent as the `X-Amz-Storage-Class` request header on CreateBucket (via per-call SDK middleware, so it is SigV4-signed); RGW records it as the storage class of the bucket's placement rule (`<placement>/<storage-class>` in bucket info), making it the default for objects written without an explicit storage class. A separate key is required because RGW's S3 `LocationConstraint` parsing takes the entire post-colon substring as the placement-target name on all supported releases (verified in reef/squid/main `rgw_rest_s3.cc`) — a `placement/storage-class` suffix there is rejected as `InvalidLocationConstraint`.

RGW bucket placement is immutable after creation, so the constraint only applies at greenfield creation. When the bucket already exists — brownfield `Grant`, idempotent re-provision, or a `bucketOwner` relink — the reconcile completes normally and the operator logs the requested constraint alongside the bucket's actual placement instead of failing.

Notes for reviewers:

- The ignored-constraint Info log repeats on every re-provision of such an OBC (operator restarts, OBC spec updates). Requested-vs-actual values are not trivially comparable (`zonegroup:` prefix, `/storage-class` suffix grammar), so no suppression is attempted.
- `Grant` returning `(nil, nil)` when the brownfield bucket does not exist is a pre-existing quirk (`errors.Wrapf(nil, ...)`) and is preserved as-is.
- Pre-existing bug surfaced by the new integration coverage (first CI exercise of brownfield `Grant`): `Grant` manages the bucket policy with the OBC user's own S3 credentials, so a brownfield claim by a freshly generated user fails (`GetBucketPolicy` → 403 `AccessDenied`) and the OBC never binds. Brownfield currently only works when the OBC also sets `bucketOwner` to a user with access to the bucket; the integration test claims the bucket as its owner. Not addressed here — out of scope for this PR.
- `bucketExists` now returns the whole `admin.Bucket` so the exists paths can log the actual placement without a second admin-ops call.

Integration coverage runs in `TestCephObjectSuite` via a new `bucket/location` package: SC-default and OBC-override placement (asserted via admin-API `placement_rule`), OBC-over-SC precedence, the default-placement control case, a `bucketStorageClass` bucket asserted as `placement_rule == "default/FOO"`, ignored-constraint logging on re-provision and brownfield Grant, and the invalid-constraint failure path. The shared store fixture gains a second, non-default pool placement backed by the same shared pools.

**AI assistance:** AI (Claude) explored the provisioner/RGW placement code paths, drafted the code, unit and integration tests, documentation edits, and this PR description.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] Reviewed [AI guidelines](https://rook.io/docs/rook/latest/Contributing/ai-guidelines), if AI assisted with the PR.
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
  - Overwriting Ceph's configurations should be marked as breaking changes.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
